### PR TITLE
ATable: Add showCount prop

### DIFF
--- a/src/ATable/ATable.js
+++ b/src/ATable/ATable.js
@@ -323,6 +323,11 @@ export default {
       required: false,
       default: () => [],
     },
+    showCount: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
     showFirstSortingSequenceNumber: {
       type: Boolean,
       required: false,
@@ -791,6 +796,7 @@ export default {
           hasViews: this.hasViews,
           viewCurrent: this.viewCurrent,
           modelView: this.modelView,
+          showCount: this.showCount,
           tableActionsIndexFirstDropdownAction: this.tableActionsIndexFirstDropdownAction,
           tableActionsIndexFirstDropdownActionMobile: this.tableActionsIndexFirstDropdownActionMobile,
           useViewSlot: this.useViewSlot,

--- a/src/ATable/ATableTopPanel/ATableTopPanel.js
+++ b/src/ATable/ATableTopPanel/ATableTopPanel.js
@@ -207,7 +207,7 @@ export default {
                 class: "a_table__top_panel__label__text",
                 text: this.label,
               }),
-              this.showCount && h(AButton, {
+              this.showCount ? h(AButton, {
                 class: "a_table__top_panel__label__count",
                 tag: "span",
                 text: this.countAllRowsFormatted,
@@ -216,7 +216,7 @@ export default {
                 extra: {
                   count: this.countAllRows,
                 },
-              }),
+              }) : "",
             ]) :
           "",
         h("div", {

--- a/src/ATable/ATableTopPanel/ATableTopPanel.js
+++ b/src/ATable/ATableTopPanel/ATableTopPanel.js
@@ -92,6 +92,11 @@ export default {
       type: Array,
       required: true,
     },
+    showCount: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
     tableActions: {
       type: Array,
       required: true,
@@ -202,7 +207,7 @@ export default {
                 class: "a_table__top_panel__label__text",
                 text: this.label,
               }),
-              h(AButton, {
+              this.showCount && h(AButton, {
                 class: "a_table__top_panel__label__count",
                 tag: "span",
                 text: this.countAllRowsFormatted,


### PR DESCRIPTION
Adds ``showCount`` prop to ``ATable`` and ``ATableTopPanel``.

``showCount`` controls the visibility of the total number of entries in the table after the table label.