### PR TITLE
APageTabTitle watches i18n changes

### DIFF
--- a/src/compositionAPI/APageTabTitleAPI.js
+++ b/src/compositionAPI/APageTabTitleAPI.js
@@ -67,7 +67,7 @@ export default function APageTabTitleAPI(props) {
 
   setPageTabTitle();
 
-  watch(title, () => {
+  watch(titleTranslated, () => {
     setPageTabTitle();
   });
 }


### PR DESCRIPTION
Solves a bug, where the pagetitle was not updated with translations. 

When starting out without i18n data, the untranslated title was set. After adding the required translations, the title was not updated with the new translations.