### PR TITLE
tinymce context: remove paste

### DIFF
--- a/src/ui/ATinymce/compositionAPI/ATinymceAPI.js
+++ b/src/ui/ATinymce/compositionAPI/ATinymceAPI.js
@@ -82,7 +82,7 @@ export default function ATinymceAPI(props, context, {
       content_css: false,
       content_langs: contentLangs.value,
       content_style: contentStyle.value,
-      contextmenu: "copy paste",
+      contextmenu: "copy link",
       entity_encoding: "raw",
       force_br_newlines: true,
       indent: false,


### PR DESCRIPTION
tinyMCE doesn't implement yet past functionality by context menu with new clipboard API
only by Strg+V