### PR TITLE
update tinyMCE to version 6.8.5

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
     "lodash-es": "4.17.21",
     "moment": "2.29.4",
     "tiny-emitter": "2.1.0",
-    "tinymce": "6.6.1",
+    "tinymce": "6.8.5",
     "vue": "3.4.8",
     "vue-router": "4.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash-es": "^4.17.21",
     "moment": "2.30.1",
     "tiny-emitter": "^2.1.0",
-    "tinymce": "6.6.1",
+    "tinymce": "6.8.5",
     "vue": "3.4.8"
   },
   "devDependencies": {


### PR DESCRIPTION
update tinyMCE to version 6.8.5 (current latest major version 6, licence MIT) 
reason:  bug in UI, cursor placed bottom of content and hit enter cause jump the editor view out of cursor position.  Information: https://github.com/tinymce/tinymce/issues/8832

